### PR TITLE
Fixed storyboard outlets.

### DIFF
--- a/tableViewTraining/Base.lproj/Main.storyboard
+++ b/tableViewTraining/Base.lproj/Main.storyboard
@@ -267,8 +267,9 @@
                     <connections>
                         <outlet property="newCatImage" destination="9nj-Kb-DxH" id="saj-vo-Pcs"/>
                         <outlet property="newCatName" destination="k9F-sh-4b1" id="mDg-Rk-GBQ"/>
-                        <outlet property="newCatPlace" destination="A8N-2T-wny" id="PTm-0B-irg"/>
+                        <outlet property="newCatPlace" destination="h1y-NP-TVS" id="Hoo-M9-WQV"/>
                         <outlet property="newCatQuote" destination="4MX-b0-dX6" id="FxX-UY-3hO"/>
+                        <outlet property="saveButton" destination="AST-aS-Ybt" id="GRA-Nz-bEA"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="hzu-yC-CiD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
See `NewCatViewController`.

- `@IBOutlet var newCatPlace: UITextField!` was linked to content view not to TextField - fixed.
- `@IBOutlet var saveButton: UIBarButtonItem!` was not linked at all - fixed.
